### PR TITLE
Hide board comment when displaying application

### DIFF
--- a/client/views/statutory/ViewApplication.vue
+++ b/client/views/statutory/ViewApplication.vue
@@ -76,11 +76,11 @@
                   <td v-if="application.participant_order">{{ application.participant_order }}</td>
                   <td v-if="!application.participant_order"><i>Not set yet.</i></td>
                 </tr>
-                <tr>
+                <!--<tr>
                   <th>Board comment</th>
                   <td v-if="application.board_comment">{{ application.board_comment }}</td>
                   <td v-if="!application.board_comment"><i>Not set yet.</i></td>
-                </tr>
+                </tr>-->
               </tbody>
             </table>
           </div>


### PR DESCRIPTION
As Chair team mentioned:

We received some complaints from applicants for the EPM and boards that the board comments in OMS seem to be visible to the applicants. Could you check this and if yes, disable this functionality, as this could limit boards in making honest comments in the future.

Thank you already! We wish you a merry Christmas and a happy new year!

To be merged ASAP.