### PR TITLE
fix(docker): remove useless mount

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,12 +13,10 @@ RUN adduser -D -H -u 1000 -s /bin/bash www-data -G www-data
 COPY --from=builder /usr/app/src /usr/app/src
 COPY ./docker/oms-frontend-nginx/nginx.conf /etc/nginx/nginx.conf
 COPY ./docker/oms-frontend-nginx/sites/default.conf /etc/nginx/sites-available/default.conf
-COPY ./docker/bootstrap-dev.sh /usr/app/scripts/bootstrap-dev.sh
 
 # it has some default settings there which result in displaying
 # the default nginx page, which is not what we need
-RUN rm -rf /etc/nginx/conf.d \
-      && chmod +x /usr/app/scripts/bootstrap-dev.sh
+RUN rm -rf /etc/nginx/conf.d
 
 RUN apk add curl
 

--- a/docker/bootstrap-dev.sh
+++ b/docker/bootstrap-dev.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-apk add nodejs npm
-npm install
-npm run build
-chmod -R 777 /usr/app/src/
-nginx

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -8,5 +8,3 @@ services:
         image: aegee/oms-frontend:dev
         volumes:
             - /usr/app/src/node_modules
-            - ./${PATH_OMS_FRONTEND}/../:/usr/app/src
-        command: "/bin/sh /usr/app/scripts/bootstrap-dev.sh" #FIXME: npm is not present in the final img


### PR DESCRIPTION
The mounts do not speed up anything, rather slow people down.
As the container has to be rebuilt anyway, this way it just works