### PR TITLE
feat: compress the output using gz/zopfli and brotli

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,5 +77,8 @@
     "semantic-release": "^17.0.4",
     "vue-loader": "^15.8.3",
     "vue-template-compiler": "^2.6.10"
+  },
+  "optionalDependencies": {
+    "iltorb": "^2.4.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   "devDependencies": {
     "@babel/types": "^7.7.4",
     "@commitlint/config-conventional": "^8.2.0",
+    "@gfx/zopfli": "^1.0.14",
     "@semantic-release/changelog": "^5.0.0",
     "@semantic-release/git": "^9.0.0",
     "@vue/cli-plugin-babel": "^4.1.0",
@@ -65,6 +66,7 @@
     "@vue/eslint-config-airbnb": "^5.0.0",
     "babel-eslint": "^10.0.3",
     "commitlint": "^8.2.0",
+    "compression-webpack-plugin": "^3.1.0",
     "conventional-changelog": "^3.1.18",
     "css-loader": "^3.4.0",
     "eslint": "^6.8.0",

--- a/vue.config.js
+++ b/vue.config.js
@@ -18,3 +18,18 @@ module.exports = {
     }
   }
 }
+
+if (process.env.NODE_ENV === 'production') {
+  const CompressionPlugin = require('compression-webpack-plugin');
+
+  module.exports.configureWebpack.plugins = [
+    new CompressionPlugin({
+      algorithm: require("@gfx/zopfli").gzip,
+      compressionOptions: {
+        numiterations: 15
+      },
+      minRatio: 0.99,
+      test:  /\.(js|css|json|html|ico|svg)(\?.*)?$/i
+    })
+  ];
+}

--- a/vue.config.js
+++ b/vue.config.js
@@ -32,4 +32,21 @@ if (process.env.NODE_ENV === 'production') {
       test:  /\.(js|css|json|html|ico|svg)(\?.*)?$/i
     })
   ];
+  if (require('zlib').brotliCompress) // Since Node 11.7
+    module.exports.configureWebpack.plugins.push(
+      new CompressionPlugin({
+        filename: '[path].br[query]',
+        algorithm: 'brotliCompress',
+        compressionOptions: { level:11 }, //matches BROTLI_MAX_QUALITY
+        minRatio: 0.99,
+        test:  /\.(js|css|json|html|ico|svg)(\?.*)?$/i
+    }));
+  else //install optionalDependency iltorb
+    module.exports.configureWebpack.plugins.push(
+      new CompressionPlugin({
+        filename: '[path].br[query]',
+        algorithm: require('iltorb').compress,
+        minRatio: 0.99,
+        test:  /\.(js|css|json|html|ico|svg)(\?.*)?$/i
+    }));
 }


### PR DESCRIPTION
As homework:
* enable in nginx `gzip_static on;` so that the .gz files are delivered to the users.
* ensure that Node JS is at least 11.7 or install optional dependency iltorb
* ensure that nginx has the [ngx_brotli](https://github.com/google/ngx_brotli) module .
* enable in nginx `brotli_static on;` so that the .br files are delivered to the users.