### PR TITLE
fix(.browserslist): don't generate code for IE mobile 10

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,2 +1,5 @@
 > 1%
 last 2 versions
+not IE 10     # Per https://www.ssllabs.com/ssltest/analyze.html?d=my.aegee.eu
+not IE_Mob 11 # Internet Explorer Desktop 10, IE Mobile 10 and IE Mobile 11
+not IE_Mob 10 # cannot connect to https://my.aegee.eu .


### PR DESCRIPTION
Per https://www.ssllabs.com/ssltest/analyze.html?d=my.aegee.eu Internet Explorer Desktop 10, IE Mobile 10 and IE Mobile 11 cannot connect to https://my.aegee.eu.