### PR TITLE
fix(sidebar): fix sidebar being stuck for mobile

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -63,6 +63,7 @@ h1, h2, h3, h4, h5, h6 {
 @import '~@fullcalendar/core/main.min.css';
 @import '~@fullcalendar/daygrid/main.min.css';
 @import '~mapbox-gl/dist/mapbox-gl.css';
+@import '~animate.css/animate.min.css';
 
 @import '~nprogress/nprogress.css';
 


### PR DESCRIPTION
somehow animate.css was used and wasn't imported, so styles weren't applied, that's why sidebar was stuck.