### PR TITLE
fix(sidebar): fix sidebar being stuck for mobile, again

### DIFF
--- a/src/components/layout/Sidebar.vue
+++ b/src/components/layout/Sidebar.vue
@@ -1,5 +1,5 @@
 <template>
-  <aside class="menu app-sidebar animated" :class="{ slideInLeft: show, slideOutLeft: !show, 'is-menu-opened': navbar.menuOpened }">
+  <aside class="menu app-sidebar animate__animated" :class="{ animate__slideInLeft: show, animate__slideOutLeft: !show, 'is-menu-opened': navbar.menuOpened }">
     <div v-for="category in filteredMenu" v-bind:key="category.categoryName">
       <p class="menu-label">
         {{ category.categoryName }}


### PR DESCRIPTION
apparently upgrading animate.css to 4.x was a breaking change and all of the classes have `animate__` prefix before them: https://animate.style/#migration