### PR TITLE
fix(question line): Remove unused id

### DIFF
--- a/src/views/statutory/QuestionLinesList.vue
+++ b/src/views/statutory/QuestionLinesList.vue
@@ -12,9 +12,6 @@
 
         <b-table :data="questionLines" :loading="isLoading" :selected.sync="selectedQuestionLine" narrowed>
           <template slot-scope="props">
-            <b-table-column field="id" label="#" numeric>
-              {{ props.row.id }}
-            </b-table-column>
 
             <b-table-column field="name" label="Name">
               {{ props.row.name }}


### PR DESCRIPTION
Internal IDs show up so the question lines for Spring Agora 2020 start at 16. As this is ugly, I propose to just delete showing IDs