### PR TITLE
fix(bodies): allow setting bodies as deleted

### DIFF
--- a/src/fontawesome.js
+++ b/src/fontawesome.js
@@ -58,6 +58,7 @@ import { faCommentAlt } from '@fortawesome/free-solid-svg-icons/faCommentAlt'
 import { faInfoCircle } from '@fortawesome/free-solid-svg-icons/faInfoCircle'
 import { faTrashAlt } from '@fortawesome/free-solid-svg-icons/faTrashAlt'
 import { faCoins } from '@fortawesome/free-solid-svg-icons/faCoins'
+import { faExclamationCircle } from '@fortawesome/free-solid-svg-icons/faExclamationCircle'
 
 
 library.add(faTimesCircle)
@@ -116,5 +117,6 @@ library.add(faCommentAlt)
 library.add(faInfoCircle)
 library.add(faTrashAlt)
 library.add(faCoins)
+library.add(faExclamationCircle)
 
 export default FontAwesomeIcon

--- a/src/views/core/bodies/Single.vue
+++ b/src/views/core/bodies/Single.vue
@@ -217,7 +217,7 @@ export default {
       })
     },
     deleteBody () {
-      this.axios.delete(this.services['oms-core-elixir'] + '/bodies/' + this.$route.params.id).then(() => {
+      this.axios.put(this.services['oms-core-elixir'] + '/bodies/' + this.$route.params.id + '/status', { status: 'deleted' }).then(() => {
         this.$root.showSuccess('Body is deleted.')
         this.$router.push({ name: 'oms.bodies.list' })
       }).catch((err) => this.$root.showError('Could not delete body', err))


### PR DESCRIPTION
there's no DELETE /bodies/:id endpoint anymore, there's PUT /bodies/:id/status now, as bodies are not physically deleted. this reflects changes on the backend, I somehow forgot to add it there.

also adding fa-exclamation-circle icon to display the icon on notification popup